### PR TITLE
Add footer links from ++ to main template

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,44 @@
     </main>
     <footer class="container">
       <div class="row">
+        <div class="col-3">
+          <h4 class="text-center">&nbsp;</h4>
+          <img src="/assets/images/laChicaCode.png" alt="Chica waving" />
+        </div>
+        <div class="col-6">
+          <h4 class="text-center">Code Chica Guides</h4>
+          <ul class="learn-navigation">
+            <li><a href="/plus-plus/guides/html.html">HTML</a></li>
+            <li><a href="/plus-plus/guides/css.html">CSS</a></li>
+            <li><a href="/plus-plus/guides/javascript.html">JavaScript</a></li>
+            <li><a href="/plus-plus/guides/markdown.html">Markdown</a></li>
+            <li><a href="/plus-plus/guides/terminal.html">Terminal</a></li>
+            <!-- <li><a href="/plus-plus/guides/golang.html">Go</a></li> -->
+            <!-- <li><a href="/plus-plus/guides/ruby.html">Ruby</a></li> -->
+            <li><a href="/plus-plus/guides/git.html">Git</a></li>
+            <!-- <li><a href="/plus-plus/guides/linux.html">Linux</a></li> -->
+            <li><a href="/plus-plus/guides/vscode.html">VS Code</a></li>
+            <li><a href="/plus-plus/guides/slack.html">Slack</a></li>
+            <li><a href="/plus-plus/guides/github.html">GitHub</a></li>
+          </ul>
+        </div>
+        <div class="col-3">
+          <h4 class="text-center">Contribute</h4>
+          <ul class="navigation">
+            <li><a href="/plus-plus/graduates.html">Graduates</a></li>
+            <li><a href="/plus-plus/speakers.html">Guest Speakers</a></li>
+            <li><a href="https://github.com/CodeChica">GitHub</a></li>
+            <li><a href="https://www.youtube.com/playlist?list=PLaZatV79bZCRtD6yCw-goNH5Keh8ovMQp" target="_blank">YouTube</a></li>
+            <li><a href="/plus-plus/books.html">Books</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="row">
         <div class="col-12">
+          <p class="text-center font-medium">
+            Need help? Ask for help in our <a href="https://github.com/CodeChica/plus-plus/discussions">discussion forum</a> or in <a href="https://codechica-plus-plus.slack.com/">Slack</a> and we’ll help you sort it out.
+          </p>
+          <p class="text-center font-small"><a href="https://github.com/CodeChica/CodeChica/edit/main/{{ page.path }}">edit</a></p>
           <p class="text-center font-small">&copy;2021 <a href="https://latinitasonline.org/" class="link">Latinitas</a>. All rights reserved.</p>
         </div>
       </div>


### PR DESCRIPTION
# Why is this needed?

Want to make these links available across the entire site so we can share resources across both cohorts

## What does this do?

Update the default template to use footer links from ++ template. 

## Type of change

- [ ] Content edits
