### PR TITLE
Publish CodeChica++ lesson 0x04

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,6 +6,8 @@ layout: default
 <a href="https://www.eventbrite.com/e/code-chica-advanced-coding-program-cohort-2-saturdays-tickets-215146768777" class="button primary">Register Now</a>
 -->
 
+gab c was here!
+
 <div>
   <a href="/-/" class="link">
     <img src="/assets/images/code-chica.png" alt="CodeChica" style="width: 49%" />

--- a/plus-plus/index.md
+++ b/plus-plus/index.md
@@ -15,7 +15,7 @@ a place to sparkle others with kindness.
 | 0x01 | [Source control and Git](./lessons/0x01/)   | January. 22, 2022 | 11:00-14:00 CT | |
 | 0x02 | [Tech Roles Overview](./lessons/0x02/)      | January. 29, 2022 | 11:00-14:00 CT | [Rachel Potvin](https://github.com/rachelpotvin) |
 | 0x03 | [Collaborating with others](./lessons/0x03/) | Februrary. 05, 2022 | 11:00-14:00 CT | [Rosemary Sanchez](https://github.com/rrrosemaryyy) |
-| 0x04 | The Software Engineer's role | Februrary. 12, 2022 | 11:00-14:00 CT | |
+| 0x04 | [The Software Engineer's role](./lessons/0x04/) | Februrary. 12, 2022 | 11:00-14:00 CT | []() |
 | 0x05 | Exploring SparkleHub   | February. 19, 2022 | 11:00-14:00 CT | |
 | 0x06 | User Stories Applied | February. 26, 2022 | 11:00-14:00 CT | |
 | 0x07 | Final Project work | March. 05, 2022 | 11:00-14:00 CT | [Sofia Bonnet](https://github.com/sofiatwins) |

--- a/plus-plus/lessons/0x04/index.md
+++ b/plus-plus/lessons/0x04/index.md
@@ -10,8 +10,6 @@ You will get to try out either the [Product Manager][product-manager],
 By the end of this lesson you will:
 
 * learn about the role of the Software Engineer.
-* form teams and learn the [final project requirements][final].
-* get to try out the role of either [Product Manager][product-manager], [Designer][designer] or [Engineer][engineer].
 
 {% include youtube.html youtube_id="VSraiYX6Pl4" %}
 
@@ -21,10 +19,6 @@ By the end of this lesson you will:
 
 1. [The Software Game](./slides.html)
 1. [Mini Coding Challenge](#warmup---mini-coding-challenge)
-1. [Sam Klein, UX Designer](#guest-speaker--sam-klein)
-1. [Example](#example--adding-confetti-to-sparklehub)
-1. [Meet your teams](#activity---meet-your-teams)
-1. [Heart, Fart and Shopping Cart](https://docs.google.com/document/d/1STo59fviyZraDr28txpKQUmQROLaVsEhyZT-QDtyjwc/edit?usp=sharing)
 
 <hr />
 


### PR DESCRIPTION
# Why is this needed?

I need to publish this to the website so that my class know what they are
supposed to learn today and so that I know what I'm supposed to teach them.

## What does this do?

It adds a link to the new lesson page and it updates the agenda for that lesson.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
